### PR TITLE
Add JsonSchema feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ bytemuck_derive = "1.8.1"
 hashbrown = { version = "0.15.2", default-features = false }
 regex-syntax = "0.8.5"
 strum = { version = "0.27.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive" ] }
+schemars = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.217", features = ["derive"] }
@@ -35,5 +37,6 @@ default = ["compress", "ahash"]
 # default = ["ahash"]
 compress = []
 ahash = ["dep:ahash"]
+jsonschema = ["schemars"]
 
 # [workspace]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,8 +8,10 @@ use crate::HashMap;
 use crate::{hashcons::VecHashCons, pp::PrettyPrinter, simplify::OwnedConcatElement};
 use bytemuck_derive::{Pod, Zeroable};
 use strum::FromRepr;
+use serde::{Deserialize, Serialize};
 
-#[derive(Pod, Zeroable, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Pod, Zeroable, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct ExprRef(pub(crate) u32);
 
@@ -332,21 +334,54 @@ impl<'a> Expr<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct ExprSet {
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     exprs: VecHashCons,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     expr_weight: Vec<(u32, u32)>,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) alphabet_size: usize,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) alphabet_words: usize,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) digits: [u8; 10],
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) digit_dot: u8,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) cost: u64,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pp: PrettyPrinter,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) optimize: bool,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) unicode_cache: HashMap<Vec<(char, char)>, ExprRef>,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) any_unicode_star: ExprRef,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) any_unicode: ExprRef,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     pub(crate) any_unicode_non_nl: ExprRef,
+}
+
+impl Default for ExprSet {
+    fn default() -> Self {
+        Self::new(256)
+    }
 }
 
 const ATTR_HAS_REPEAT: u32 = 1;
@@ -730,7 +765,8 @@ impl ExprSet {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum NextByte {
     /// Transition via any other byte, or EOI leads to a dead state.
     ForcedByte(u8),

--- a/src/deriv.rs
+++ b/src/deriv.rs
@@ -1,6 +1,7 @@
 use crate::HashMap;
 
 use crate::ast::{Expr, ExprRef, ExprSet};
+use serde::{Deserialize, Serialize};
 
 const DEBUG: bool = false;
 macro_rules! debug {
@@ -12,7 +13,8 @@ macro_rules! debug {
     };
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct DerivCache {
     pub num_deriv: usize,
     state_table: HashMap<(ExprRef, u8), ExprRef>,

--- a/src/hashcons.rs
+++ b/src/hashcons.rs
@@ -4,8 +4,9 @@ use std::hash::{BuildHasher, Hasher};
 use hashbrown::HashTable;
 
 use crate::RandomState;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 struct Element {
     backing_start: u32,
     backing_end: u32,
@@ -20,12 +21,23 @@ impl Element {
 /// A hashconsing data structure for vectors of u32.
 /// Given a vector, it stores it only once and returns a unique id.
 /// The ids are consecutive and start at 0.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct VecHashCons {
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     hasher: RandomState,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     backing: Vec<u32>,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     elements: Vec<Element>,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     table: HashTable<u32>,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     curr_elt: Element,
 }
 

--- a/src/nextbyte.rs
+++ b/src/nextbyte.rs
@@ -1,8 +1,10 @@
 use crate::HashMap;
 
 use crate::ast::{Expr, ExprRef, ExprSet, NextByte};
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct NextByteCache {
     next_byte_cache: HashMap<ExprRef, NextByte>,
 }

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -15,6 +15,12 @@ pub struct PrettyPrinter {
     has_mapping: bool,
 }
 
+impl Default for PrettyPrinter {
+    fn default() -> Self {
+        Self::new_simple(256)
+    }
+}
+
 impl PrettyPrinter {
     pub fn expr_to_string(&self, exprset: &ExprSet, id: ExprRef, max_len: usize) -> String {
         let mut s = String::new(); // format!("|{}| ", exprset.get_weight(id));

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -12,6 +12,7 @@ use crate::{
     pp::PrettyPrinter,
     relevance::RelevanceCache,
 };
+use serde::{Deserialize, Serialize};
 
 const DEBUG: bool = false;
 
@@ -23,7 +24,8 @@ macro_rules! debug {
     };
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct StateID(u32);
 
 impl StateID {
@@ -84,25 +86,43 @@ impl Debug for StateID {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct AlphabetInfo {
     mapping: [u8; 256],
     size: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct Regex {
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     exprs: ExprSet,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     deriv: DerivCache,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     next_byte: NextByteCache,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     relevance: RelevanceCache,
     alpha: AlphabetInfo,
     initial: StateID,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     rx_sets: VecHashCons,
     state_table: Vec<StateID>,
     state_descs: Vec<StateDesc>,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     num_transitions: usize,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     num_ast_nodes: usize,
+    #[serde(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     max_states: usize,
 }
 

--- a/src/regexbuilder.rs
+++ b/src/regexbuilder.rs
@@ -14,15 +14,18 @@ use crate::{
     simplify::ConcatElement,
     ExprRef, Regex,
 };
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct RegexBuilder {
     parser_builder: ParserBuilder,
     exprset: ExprSet,
     json_quote_cache: HashMap<ExprRef, ExprRef>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct JsonQuoteOptions {
     /// Which escapes to allow (after \).
     /// Represents a set of bytes. Allowed bytes:
@@ -72,7 +75,8 @@ impl JsonQuoteOptions {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum RegexAst {
     /// Intersection of the regexes
     And(Vec<RegexAst>),

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -9,6 +9,7 @@ use crate::{
     simplify::{ConcatElement, OwnedConcatElement},
     NextByte,
 };
+use serde::{Deserialize, Serialize};
 
 // This is map (ByteSet => RegExp); ByteSet is Expr::Byte or Expr::ByteSet,
 // and expresses the condition; RegExp is the derivative under that condition.
@@ -30,7 +31,8 @@ macro_rules! debug {
     };
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct RelevanceCache {
     relevance_cache: HashMap<ExprRef, bool>,
     containment_cache: HashMap<(ExprRef, ExprRef), bool>,


### PR DESCRIPTION
## Summary
- add optional `schemars` dependency and `jsonschema` feature
- derive `Serialize`, `Deserialize`, and optionally `JsonSchema` for public types
- provide defaults for skipped fields

## Testing
- `cargo check --features jsonschema` *(fails: failed to fetch crates; network access is restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68626adbd970832aa80933cd66fb09c0